### PR TITLE
Add use for enum variants

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,8 @@
 use std::default::Default;
 use std::fmt;
 
+pub use self::ConfigError::{ZeroPoolSize, ZeroHelperTasks};
+
 /// A struct specifying the runtime configuration of a pool.
 ///
 /// `Config` implements `Default`, which provides a set of reasonable default


### PR DESCRIPTION
Rust added proper namespacing of enums in the latest nightly (rust-lang/rust#18973).

I realize now you're probably aware of that change.  :)
