### PR TITLE
Nightly fixes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 extern crate log;
 extern crate time;
 
-use std::collections::RingBuf;
+use std::collections::VecDeque;
 use std::error::Error;
 use std::fmt;
 use std::ops::{Deref, DerefMut};
@@ -74,7 +74,7 @@ impl<E> ErrorHandler<E> for LoggingErrorHandler where E: fmt::Debug {
 }
 
 struct PoolInternals<C> {
-    conns: RingBuf<C>,
+    conns: VecDeque<C>,
     num_conns: u32,
 }
 
@@ -170,7 +170,7 @@ impl<M> Pool<M> where M: ConnectionManager {
                error_handler: Box<ErrorHandler<<M as ConnectionManager>::Error>>)
                -> Result<Pool<M>, InitializationError> {
         let internals = PoolInternals {
-            conns: RingBuf::new(),
+            conns: VecDeque::new(),
             num_conns: 0,
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,9 +24,9 @@ pub mod config;
 mod task;
 
 /// A trait which provides connection-specific functionality.
-pub trait ConnectionManager: Send+Sync {
-    type Connection: Send;
-    type Error;
+pub trait ConnectionManager: Send+Sync+'static {
+    type Connection: Send + 'static;
+    type Error : 'static;
 
     /// Attempts to create a new connection.
     fn connect(&self) -> Result<Self::Connection, Self::Error>;
@@ -50,7 +50,7 @@ pub trait ConnectionManager: Send+Sync {
 }
 
 /// A trait which handles errors reported by the `ConnectionManager`.
-pub trait ErrorHandler<E>: Send+Sync {
+pub trait ErrorHandler<E>: Send+Sync+'static {
     /// Handles an error.
     fn handle_error(&self, error: E);
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -110,11 +110,11 @@ impl ScheduledThreadPool {
     }
 
     #[allow(unused)]
-    pub fn run<F>(&self, job: F) where F: FnOnce() + Send {
+    pub fn run<F>(&self, job: F) where F: FnOnce() + Send + 'static {
         self.run_after(Duration::zero(), job)
     }
 
-    pub fn run_after<F>(&self, dur: Duration, job: F) where F: FnOnce() + Send {
+    pub fn run_after<F>(&self, dur: Duration, job: F) where F: FnOnce() + Send + 'static {
         let job = Job {
             type_: JobType::Once(Thunk::new(job)),
             time: (time::precise_time_ns() as i64 + dur.num_nanoseconds().unwrap()) as u64,
@@ -123,7 +123,7 @@ impl ScheduledThreadPool {
     }
 
     #[allow(unused)]
-    pub fn run_at_fixed_rate<F>(&self, rate: Duration, f: F) where F: FnMut() + Send {
+    pub fn run_at_fixed_rate<F>(&self, rate: Duration, f: F) where F: FnMut() + Send + 'static {
         let job = Job {
             type_: JobType::FixedRate { f: Box::new(f), rate: rate },
             time: (time::precise_time_ns() as i64 + rate.num_nanoseconds().unwrap()) as u64,

--- a/src/task.rs
+++ b/src/task.rs
@@ -222,7 +222,7 @@ mod test {
         for _ in range(0, TEST_TASKS) {
             let tx = tx.clone();
             pool.run(move|| {
-                tx.send(1us).unwrap();
+                tx.send(1usize).unwrap();
             });
         }
 
@@ -257,7 +257,7 @@ mod test {
             let waiter = waiter.clone();
             pool.run(move || {
                 waiter.wait();
-                tx.send(1us).unwrap();
+                tx.send(1usize).unwrap();
             });
         }
 
@@ -270,8 +270,8 @@ mod test {
         let (tx, rx) = channel();
 
         let tx1 = tx.clone();
-        pool.run_after(Duration::seconds(1), move || tx1.send(1us).unwrap());
-        pool.run_after(Duration::milliseconds(500), move || tx.send(2us).unwrap());
+        pool.run_after(Duration::seconds(1), move || tx1.send(1usize).unwrap());
+        pool.run_after(Duration::milliseconds(500), move || tx.send(2usize).unwrap());
 
         assert_eq!(2, rx.recv().unwrap());
         assert_eq!(1, rx.recv().unwrap());
@@ -283,8 +283,8 @@ mod test {
         let (tx, rx) = channel();
 
         let tx1 = tx.clone();
-        pool.run_after(Duration::seconds(1), move || tx1.send(1us).unwrap());
-        pool.run_after(Duration::milliseconds(500), move || tx.send(2us).unwrap());
+        pool.run_after(Duration::seconds(1), move || tx1.send(1usize).unwrap());
+        pool.run_after(Duration::milliseconds(500), move || tx.send(2usize).unwrap());
 
         drop(pool);
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -8,9 +8,9 @@ use std::time::Duration;
 use time;
 
 enum JobType {
-    Once(Thunk),
+    Once(Thunk<'static>),
     FixedRate {
-        f: Box<FnMut() + Send>,
+        f: Box<FnMut() + Send + 'static>,
         rate: Duration,
     },
 }


### PR DESCRIPTION
Fix breakage & some warnings. I've left the:
```
src/task.rs:150:13: 150:26 warning: use of deprecated item: use module-level free fucntion, #[warn(deprecated)] on by default
```

warnings as I'm not clear on what the solution there is.