### PR TITLE
Add a `connections()` method to `Pool`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,6 +355,23 @@ impl<M> Pool<M>
         Ok(Pool(shared))
     }
 
+    /// Retrieves the current number of connections in the pool.
+    pub fn connections(&self) -> u32 {
+        let internals = self.0.internals.lock();
+        internals.num_conns
+    }
+
+    /// Retrieves the current number of idle connections in the pool.
+    pub fn idle_connections(&self) -> usize {
+        let internals = self.0.internals.lock();
+        internals.conns.len()
+    }
+
+    /// Retrieves the current configuration.
+    pub fn config(&self) -> &Config<M::Connection, M::Error> {
+        &self.0.config
+    }
+
     /// Retrieves a connection from the pool.
     ///
     /// Waits for at most `Config::connection_timeout` before returning an


### PR DESCRIPTION
This method simply returns the number of connections currently
open. This is very useful for health checking the pool as a whole.
If, for example, this method consistently returns a number less
than `min_idle` it means you are in trouble. If it falls to zero
then none of your servers is up. A good use case for this is
monitoring your servers.

While the same info is included when you debug print the pool,
which is very helpful during development to track down a bug,
exposing this info in a public method like this makes it feasible
to act on it in production.