### PR TITLE
Add `Pool#get_immediately`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,7 +375,7 @@ impl<M> Pool<M>
         let end = Instant::now() + self.0.config.connection_timeout();
 
         loop {
-            if let Some(conn) = self.get_immediately() {
+            if let Some(conn) = self.try_get() {
                 return Ok(conn);
             } else {
                 let mut internals = self.0.internals.lock();
@@ -399,7 +399,7 @@ impl<M> Pool<M>
     ///
     /// Returns `None` if there are no idle connections available in the pool.
     /// This method will not attempt to establish a new connection.
-    fn get_immediately(&self) -> Option<PooledConnection<M>> {
+    fn try_get(&self) -> Option<PooledConnection<M>> {
         let mut internals = self.0.internals.lock();
 
         loop {

--- a/src/test.rs
+++ b/src/test.rs
@@ -99,13 +99,13 @@ fn test_acquire_release() {
 }
 
 #[test]
-fn get_immediately() {
+fn try_get() {
     let config = Config::builder().pool_size(2).build();
     let pool = Pool::new(config, OkManager).unwrap();
 
-    let conn1 = pool.get_immediately();
-    let conn2 = pool.get_immediately();
-    let conn3 = pool.get_immediately();
+    let conn1 = pool.try_get();
+    let conn2 = pool.try_get();
+    let conn3 = pool.try_get();
 
     assert!(conn1.is_some());
     assert!(conn2.is_some());
@@ -113,7 +113,7 @@ fn get_immediately() {
 
     drop(conn1);
 
-    assert!(pool.get_immediately().is_some());
+    assert!(pool.try_get().is_some());
 }
 
 #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -99,6 +99,24 @@ fn test_acquire_release() {
 }
 
 #[test]
+fn get_immediately() {
+    let config = Config::builder().pool_size(2).build();
+    let pool = Pool::new(config, OkManager).unwrap();
+
+    let conn1 = pool.get_immediately();
+    let conn2 = pool.get_immediately();
+    let conn3 = pool.get_immediately();
+
+    assert!(conn1.is_some());
+    assert!(conn2.is_some());
+    assert!(conn3.is_none());
+
+    drop(conn1);
+
+    assert!(pool.get_immediately().is_some());
+}
+
+#[test]
 fn test_is_send_sync() {
     fn is_send_sync<T: Send + Sync>() {}
     is_send_sync::<Pool<OkManager>>();


### PR DESCRIPTION
This method behaves the same as `get`, except that it will not attempt
to establish new connections, and will not wait for a connection to
become available. This is useful for users who may wish to attempt to
parallelize a task over multiple connections, but only if there are
enough idle connections already available.