### PR TITLE
Add r2d2-odbc to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Backend                                                             | Adaptor Cr
 [rusted-cypher](https://github.com/livioribeiro/rusted-cypher)      | [r2d2-cypher](https://github.com/flosse/r2d2-cypher)
 [diesel](https://github.com/sgrif/diesel)                           | [r2d2-diesel](https://github.com/sgrif/r2d2-diesel)
 [couchdb](https://github.com/chill-rs/chill)                        | [r2d2-couchdb](https://github.com/scorphus/r2d2-couchdb)
+[odbc](https://github.com/Koka/odbc-rs)                             | [r2d2-odbc](https://github.com/Koka/r2d2-odbc)
 
 # Example
 


### PR DESCRIPTION
Hi, I've recently made a simple adapter which allows to use ODBC connections with r2d2 connection pool.
It would be great if you could add link to this adapter to README so other people could find this adapter easily.