### PR TITLE
Add mongodb/r2d2-mongodb to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,17 @@ check the health of connections.
 
 A (possibly not exhaustive) list of adaptors for different backends:
 
-Backend                                                             | Adaptor Crate
-------------------------------------------------------------------- | -------------
-[rust-postgres](https://github.com/sfackler/rust-postgres)          | [r2d2-postgres](https://github.com/sfackler/r2d2-postgres)
-[redis-rs](https://github.com/mitsuhiko/redis-rs)                   | [r2d2-redis](https://github.com/nevdelap/r2d2-redis)
-[rust-mysql-simple](https://github.com/blackbeam/rust-mysql-simple) | [r2d2-mysql](https://github.com/outersky/r2d2-mysql)
-[rusqlite](https://github.com/jgallagher/rusqlite)                  | [r2d2-sqlite](https://github.com/ivanceras/r2d2-sqlite)
-[rusted-cypher](https://github.com/livioribeiro/rusted-cypher)      | [r2d2-cypher](https://github.com/flosse/r2d2-cypher)
-[diesel](https://github.com/sgrif/diesel)                           | [r2d2-diesel](https://github.com/sgrif/r2d2-diesel)
-[couchdb](https://github.com/chill-rs/chill)                        | [r2d2-couchdb](https://github.com/scorphus/r2d2-couchdb)
-[odbc](https://github.com/Koka/odbc-rs)                             | [r2d2-odbc](https://github.com/Koka/r2d2-odbc)
+Backend                                                                | Adaptor Crate
+---------------------------------------------------------------------- | -------------
+[rust-postgres](https://github.com/sfackler/rust-postgres)             | [r2d2-postgres](https://github.com/sfackler/r2d2-postgres)
+[redis-rs](https://github.com/mitsuhiko/redis-rs)                      | [r2d2-redis](https://github.com/nevdelap/r2d2-redis)
+[rust-mysql-simple](https://github.com/blackbeam/rust-mysql-simple)    | [r2d2-mysql](https://github.com/outersky/r2d2-mysql)
+[rusqlite](https://github.com/jgallagher/rusqlite)                     | [r2d2-sqlite](https://github.com/ivanceras/r2d2-sqlite)
+[rusted-cypher](https://github.com/livioribeiro/rusted-cypher)         | [r2d2-cypher](https://github.com/flosse/r2d2-cypher)
+[diesel](https://github.com/sgrif/diesel)                              | [r2d2-diesel](https://github.com/sgrif/r2d2-diesel)
+[couchdb](https://github.com/chill-rs/chill)                           | [r2d2-couchdb](https://github.com/scorphus/r2d2-couchdb)
+[mongodb](https://github.com/mongodb-labs/mongo-rust-driver-prototype) | [r2d2-mongodb](https://github.com/petoknm/r2d2-mongodb)
+[odbc](https://github.com/Koka/odbc-rs)                                | [r2d2-odbc](https://github.com/Koka/r2d2-odbc)
 
 # Example
 


### PR DESCRIPTION
I created an adaptor for the mongodb backend. I just wanted to add it to the README so that people know that r2d2 supports mongodb as well.