### PR TITLE
Add an event handler

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -42,29 +42,53 @@ impl HandleEvent for NopEventHandler {}
 
 /// Information about an acquire event.
 #[derive(Debug)]
-pub struct AcquireEvent(pub(crate) ());
+pub struct AcquireEvent {
+    pub(crate) id: u64,
+}
+
+impl AcquireEvent {
+    /// Returns the ID of the connection.
+    #[inline]
+    pub fn connection_id(&self) -> u64 {
+        self.id
+    }
+}
 
 /// Information about a release event.
 #[derive(Debug)]
 pub struct ReleaseEvent {
-    pub(crate) lifetime: Duration,
+    pub(crate) id: u64,
+    pub(crate) age: Duration,
 }
 
 impl ReleaseEvent {
-    /// Returns the amount of time the connection was alive.
+    /// Returns the ID of the connection.
     #[inline]
-    pub fn lifetime(&self) -> Duration {
-        self.lifetime
+    pub fn connection_id(&self) -> u64 {
+        self.id
+    }
+
+    /// Returns the age of the connection.
+    #[inline]
+    pub fn age(&self) -> Duration {
+        self.age
     }
 }
 
 /// Information about a checkout event.
 #[derive(Debug)]
 pub struct CheckoutEvent {
+    pub(crate) id: u64,
     pub(crate) duration: Duration,
 }
 
 impl CheckoutEvent {
+    /// Returns the ID of the connection.
+    #[inline]
+    pub fn connection_id(&self) -> u64 {
+        self.id
+    }
+
     /// Returns the time taken to check out the connection.
     #[inline]
     pub fn duration(&self) -> Duration {
@@ -89,10 +113,17 @@ impl TimeoutEvent {
 /// Information about a checkin event.
 #[derive(Debug)]
 pub struct CheckinEvent {
+    pub(crate) id: u64,
     pub(crate) duration: Duration,
 }
 
 impl CheckinEvent {
+    /// Returns the ID of the connection.
+    #[inline]
+    pub fn connection_id(&self) -> u64 {
+        self.id
+    }
+
     /// Returns the amount of time the connection was checked out.
     #[inline]
     pub fn duration(&self) -> Duration {

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,0 +1,101 @@
+//! Event subscriptions.
+
+use std::fmt;
+use std::time::Duration;
+
+/// A trait which is provided with information about events in a connection pool.
+pub trait HandleEvent: fmt::Debug + Sync + Send {
+    /// Called when a new connection is acquired.
+    ///
+    /// The default implementation does nothing.
+    #[allow(unused_variables)]
+    fn handle_acquire(&self, event: AcquireEvent) {}
+
+    /// Called when a connection is released.
+    ///
+    /// The default implementation does nothing.
+    #[allow(unused_variables)]
+    fn handle_release(&self, event: ReleaseEvent) {}
+
+    /// Called when a connection is checked out from the pool.
+    ///
+    /// The default implementation does nothing.
+    #[allow(unused_variables)]
+    fn handle_checkout(&self, event: CheckoutEvent) {}
+
+    /// Called when a checkout attempt times out.
+    ///
+    /// The default implementation does nothing.
+    #[allow(unused_variables)]
+    fn handle_timeout(&self, event: TimeoutEvent) {}
+
+    /// Called when a connection is checked back into the pool.
+    #[allow(unused_variables)]
+    fn handle_checkin(&self, event: CheckinEvent) {}
+}
+
+/// A `HandleEvent` implementation which does nothing.
+#[derive(Copy, Clone, Debug)]
+pub struct NopEventHandler;
+
+impl HandleEvent for NopEventHandler {}
+
+/// Information about an acquire event.
+#[derive(Debug)]
+pub struct AcquireEvent(pub(crate) ());
+
+/// Information about a release event.
+#[derive(Debug)]
+pub struct ReleaseEvent {
+    pub(crate) lifetime: Duration,
+}
+
+impl ReleaseEvent {
+    /// Returns the amount of time the connection was alive.
+    #[inline]
+    pub fn lifetime(&self) -> Duration {
+        self.lifetime
+    }
+}
+
+/// Information about a checkout event.
+#[derive(Debug)]
+pub struct CheckoutEvent {
+    pub(crate) duration: Duration,
+}
+
+impl CheckoutEvent {
+    /// Returns the time taken to check out the connection.
+    #[inline]
+    pub fn duration(&self) -> Duration {
+        self.duration
+    }
+}
+
+/// Information about a timeout event.
+#[derive(Debug)]
+pub struct TimeoutEvent {
+    pub(crate) timeout: Duration,
+}
+
+impl TimeoutEvent {
+    /// Returns the timeout of the failed checkout attempt.
+    #[inline]
+    pub fn timeout(&self) -> Duration {
+        self.timeout
+    }
+}
+
+/// Information about a checkin event.
+#[derive(Debug)]
+pub struct CheckinEvent {
+    pub(crate) duration: Duration,
+}
+
+impl CheckinEvent {
+    /// Returns the amount of time the connection was checked out.
+    #[inline]
+    pub fn duration(&self) -> Duration {
+        self.duration
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,11 @@ use std::time::{Duration, Instant};
 
 pub use config::Builder;
 use config::Config;
+use event::{AcquireEvent, CheckinEvent, CheckoutEvent, ReleaseEvent, TimeoutEvent};
+pub use event::{HandleEvent, NopEventHandler};
 
 mod config;
+pub mod event;
 
 #[cfg(test)]
 mod test;
@@ -178,7 +181,7 @@ where
 fn drop_conns<M>(
     shared: &Arc<SharedPool<M>>,
     mut internals: MutexGuard<PoolInternals<M::Connection>>,
-    conns: Vec<M::Connection>,
+    conns: Vec<Conn<M::Connection>>,
 ) where
     M: ManageConnection,
 {
@@ -187,7 +190,11 @@ fn drop_conns<M>(
     drop(internals); // make sure we run connection destructors without this locked
 
     for conn in conns {
-        shared.config.connection_customizer.on_release(conn);
+        let event = ReleaseEvent {
+            lifetime: conn.birth.elapsed(),
+        };
+        shared.config.event_handler.handle_release(event);
+        shared.config.connection_customizer.on_release(conn.conn);
     }
 }
 
@@ -235,6 +242,9 @@ where
             });
             match conn {
                 Ok(conn) => {
+                    let event = AcquireEvent(());
+                    shared.config.event_handler.handle_acquire(event);
+
                     let mut internals = shared.internals.lock();
                     internals.last_error = None;
                     let now = Instant::now();
@@ -286,7 +296,7 @@ where
             reap |= now - conn.conn.birth >= lifetime;
         }
         if reap {
-            to_drop.push(conn.conn.conn);
+            to_drop.push(conn.conn);
         } else {
             internals.conns.push(conn);
         }
@@ -295,7 +305,9 @@ where
 }
 
 /// A generic connection pool.
-pub struct Pool<M: ManageConnection>(Arc<SharedPool<M>>);
+pub struct Pool<M>(Arc<SharedPool<M>>)
+where
+    M: ManageConnection;
 
 /// Returns a new `Pool` referencing the same state as `self`.
 impl<M> Clone for Pool<M>
@@ -395,18 +407,28 @@ where
     /// The given timeout will be used instead of the configured connection
     /// timeout.
     pub fn get_timeout(&self, timeout: Duration) -> Result<PooledConnection<M>, Error> {
-        let end = Instant::now() + timeout;
+        let start = Instant::now();
+        let end = start + timeout;
         let mut internals = self.0.internals.lock();
 
         loop {
             match self.try_get_inner(internals) {
-                Ok(conn) => return Ok(conn),
+                Ok(conn) => {
+                    let event = CheckoutEvent {
+                        duration: start.elapsed(),
+                    };
+                    self.0.config.event_handler.handle_checkout(event);
+                    return Ok(conn);
+                }
                 Err(i) => internals = i,
             }
 
             add_connection(&self.0, &mut internals);
 
             if self.0.cond.wait_until(&mut internals, end).timed_out() {
+                let event = TimeoutEvent { timeout };
+                self.0.config.event_handler.handle_timeout(event);
+
                 return Err(Error(internals.last_error.take()));
             }
         }
@@ -437,7 +459,7 @@ where
                         // FIXME we shouldn't have to lock, unlock, and relock here
                         internals = self.0.internals.lock();
                         internals.last_error = Some(msg);
-                        drop_conns(&self.0, internals, vec![conn.conn.conn]);
+                        drop_conns(&self.0, internals, vec![conn.conn]);
                         internals = self.0.internals.lock();
                         continue;
                     }
@@ -445,6 +467,7 @@ where
 
                 return Ok(PooledConnection {
                     pool: self.clone(),
+                    checkout: Instant::now(),
                     conn: Some(conn.conn),
                 });
             } else {
@@ -453,13 +476,18 @@ where
         }
     }
 
-    fn put_back(&self, mut conn: Conn<M::Connection>) {
+    fn put_back(&self, checkout: Instant, mut conn: Conn<M::Connection>) {
+        let event = CheckinEvent {
+            duration: checkout.elapsed(),
+        };
+        self.0.config.event_handler.handle_checkin(event);
+
         // This is specified to be fast, but call it before locking anyways
         let broken = self.0.manager.has_broken(&mut conn.conn);
 
         let mut internals = self.0.internals.lock();
         if broken {
-            drop_conns(&self.0, internals, vec![conn.conn]);
+            drop_conns(&self.0, internals, vec![conn]);
         } else {
             let conn = IdleConn {
                 conn: conn,
@@ -555,6 +583,7 @@ where
     M: ManageConnection,
 {
     pool: Pool<M>,
+    checkout: Instant,
     conn: Option<Conn<M::Connection>>,
 }
 
@@ -573,7 +602,7 @@ where
     M: ManageConnection,
 {
     fn drop(&mut self) {
-        self.pool.put_back(self.conn.take().unwrap());
+        self.pool.put_back(self.checkout, self.conn.take().unwrap());
     }
 }
 


### PR DESCRIPTION
This can be used by applications to better monitor their connection
pool usage. For example, you could maintain a histogram of pool checkout
times and alert if the p95 gets too high, indicating oversaturating.

cc #75