### PR TITLE
Implement asynchronous connection pool.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,11 @@ edition = "2018"
 log = "0.4"
 parking_lot = "0.9"
 scheduled-thread-pool = "0.2"
+futures-preview = "0.3.0-alpha.17"
+futures-timer = { version = "0.2.1", optional = true }
+
+[features]
+async = ["futures-timer"]
+
+[dev-dependencies]
+runtime = "0.3.0-alpha.6"

--- a/src/async_/config.rs
+++ b/src/async_/config.rs
@@ -1,0 +1,370 @@
+use futures::executor::ThreadPool;
+use futures::future::FutureObj;
+use futures::prelude::*;
+use futures::task::{Spawn, SpawnError};
+use futures_timer::TimerHandle;
+use std::fmt;
+use std::marker::PhantomData;
+use std::time::Duration;
+
+use super::{AsyncCustomizeConnection, AsyncManageConnection, AsyncPool};
+use crate::event::HandleEvent;
+use crate::{Error, HandleError, LoggingErrorHandler, NopConnectionCustomizer, NopEventHandler};
+
+/// A builder for a connection pool.
+pub struct AsyncBuilder<M>
+where
+    M: AsyncManageConnection,
+{
+    max_size: u32,
+    min_idle: Option<u32>,
+    test_on_check_out: bool,
+    max_lifetime: Option<Duration>,
+    idle_timeout: Option<Duration>,
+    connection_timeout: Duration,
+    error_handler: Box<dyn HandleError<M::Error>>,
+    connection_customizer: Box<dyn AsyncCustomizeConnection<M::Connection, M::Error>>,
+    event_handler: Box<dyn HandleEvent>,
+    spawn: Option<Box<dyn SharedSpawn + Send + Sync>>,
+    timer: Option<TimerHandle>,
+    reaper_rate: Duration,
+    _p: PhantomData<M>,
+}
+
+impl<M> fmt::Debug for AsyncBuilder<M>
+where
+    M: AsyncManageConnection,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("AsyncBuilder")
+            .field("max_size", &self.max_size)
+            .field("min_idle", &self.min_idle)
+            .field("test_on_check_out", &self.test_on_check_out)
+            .field("max_lifetime", &self.max_lifetime)
+            .field("idle_timeout", &self.idle_timeout)
+            .field("connection_timeout", &self.connection_timeout)
+            .field("error_handler", &self.error_handler)
+            .field("event_handler", &self.event_handler)
+            .field("connection_customizer", &self.connection_customizer)
+            .finish()
+    }
+}
+
+impl<M> Default for AsyncBuilder<M>
+where
+    M: AsyncManageConnection,
+{
+    fn default() -> AsyncBuilder<M> {
+        AsyncBuilder {
+            max_size: 10,
+            min_idle: None,
+            test_on_check_out: true,
+            idle_timeout: Some(Duration::from_secs(10 * 60)),
+            max_lifetime: Some(Duration::from_secs(30 * 60)),
+            connection_timeout: Duration::from_secs(30),
+            error_handler: Box::new(LoggingErrorHandler),
+            event_handler: Box::new(NopEventHandler),
+            connection_customizer: Box::new(NopConnectionCustomizer),
+            spawn: None,
+            timer: None,
+            reaper_rate: Duration::from_secs(30),
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<M> AsyncBuilder<M>
+where
+    M: AsyncManageConnection,
+{
+    /// Constructs a new `AsyncBuilder`.
+    ///
+    /// Parameters are initialized with their default values.
+    pub fn new() -> AsyncBuilder<M> {
+        AsyncBuilder::default()
+    }
+
+    /// Sets the maximum number of connections managed by the pool.
+    ///
+    /// Defaults to 10.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max_size` is 0.
+    pub fn max_size(mut self, max_size: u32) -> AsyncBuilder<M> {
+        assert!(max_size > 0, "max_size must be positive");
+        self.max_size = max_size;
+        self
+    }
+
+    /// Sets the minimum idle connection count maintained by the pool.
+    ///
+    /// If set, the pool will try to maintain at least this many idle
+    /// connections at all times, while respecting the value of `max_size`.
+    ///
+    /// Defaults to `None` (equivalent to the value of `max_size`).
+    pub fn min_idle(mut self, min_idle: Option<u32>) -> AsyncBuilder<M> {
+        self.min_idle = min_idle;
+        self
+    }
+
+    /// Sets the timer object used for asynchronous operations such as connection
+    /// creation.
+    ///
+    /// Defaults to a new pool with 3 threads.
+    pub fn spawn(mut self, spawn: Box<dyn SharedSpawn + Send + Sync>) -> AsyncBuilder<M> {
+        self.spawn = Some(spawn);
+        self
+    }
+
+    /// Sets the timer object used for asynchronous operations such as connection
+    /// creation.
+    ///
+    /// Defaults to the global timer.
+    pub fn timer(mut self, timer: TimerHandle) -> AsyncBuilder<M> {
+        self.timer = Some(timer);
+        self
+    }
+
+    /// If true, the health of a connection will be verified via a call to
+    /// `ConnectionManager::is_valid` before it is checked out of the pool.
+    ///
+    /// Defaults to true.
+    pub fn test_on_check_out(mut self, test_on_check_out: bool) -> AsyncBuilder<M> {
+        self.test_on_check_out = test_on_check_out;
+        self
+    }
+
+    /// Sets the maximum lifetime of connections in the pool.
+    ///
+    /// If set, connections will be closed after existing for at most 30 seconds
+    /// beyond this duration.
+    ///
+    /// If a connection reaches its maximum lifetime while checked out it will
+    /// be closed when it is returned to the pool.
+    ///
+    /// Defaults to 30 minutes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max_lifetime` is the zero `Duration`.
+    pub fn max_lifetime(mut self, max_lifetime: Option<Duration>) -> AsyncBuilder<M> {
+        assert_ne!(max_lifetime, Some(Duration::from_secs(0)), "max_lifetime must be positive");
+        self.max_lifetime = max_lifetime;
+        self
+    }
+
+    /// Sets the idle timeout used by the pool.
+    ///
+    /// If set, connections will be closed after sitting idle for at most 30
+    /// seconds beyond this duration.
+    ///
+    /// Defaults to 10 minutes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `idle_timeout` is the zero `Duration`.
+    pub fn idle_timeout(mut self, idle_timeout: Option<Duration>) -> AsyncBuilder<M> {
+        assert_ne!(idle_timeout, Some(Duration::from_secs(0)), "idle_timeout must be positive");
+        self.idle_timeout = idle_timeout;
+        self
+    }
+
+    /// Sets the connection timeout used by the pool.
+    ///
+    /// Calls to `Pool::get` will wait this long for a connection to become
+    /// available before returning an error.
+    ///
+    /// Defaults to 30 seconds.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `connection_timeout` is the zero duration
+    pub fn connection_timeout(mut self, connection_timeout: Duration) -> AsyncBuilder<M> {
+        assert!(
+            connection_timeout > Duration::from_secs(0),
+            "connection_timeout must be positive"
+        );
+        self.connection_timeout = connection_timeout;
+        self
+    }
+
+    /// Sets the handler for errors reported in the pool.
+    ///
+    /// Defaults to the `LoggingErrorHandler`.
+    pub fn error_handler(
+        mut self,
+        error_handler: Box<dyn HandleError<M::Error>>,
+    ) -> AsyncBuilder<M> {
+        self.error_handler = error_handler;
+        self
+    }
+
+    /// Sets the handler for events reported by the pool.
+    ///
+    /// Defaults to the `NopEventHandler`.
+    pub fn event_handler(mut self, event_handler: Box<dyn HandleEvent>) -> AsyncBuilder<M> {
+        self.event_handler = event_handler;
+        self
+    }
+
+    /// Sets the connection customizer used by the pool.
+    ///
+    /// Defaults to the `NopConnectionCustomizer`.
+    pub fn connection_customizer(
+        mut self,
+        connection_customizer: Box<dyn AsyncCustomizeConnection<M::Connection, M::Error>>,
+    ) -> AsyncBuilder<M> {
+        self.connection_customizer = connection_customizer;
+        self
+    }
+
+    // used by tests
+    #[allow(dead_code)]
+    pub(crate) fn reaper_rate(mut self, reaper_rate: Duration) -> AsyncBuilder<M> {
+        self.reaper_rate = reaper_rate;
+        self
+    }
+
+    /// Consumes the builder, returning a new, initialized pool.
+    ///
+    /// It will block until the pool has established its configured minimum
+    /// number of connections, or it times out.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the pool is unable to open its minimum number of
+    /// connections.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `min_idle` is greater than `max_size`.
+    pub fn build(self, manager: M) -> impl Future<Output = Result<AsyncPool<M>, Error>> + Send {
+        async move {
+            let pool = self.build_unchecked(manager);
+            pool.wait_for_initialization().await?;
+            Ok(pool)
+        }
+    }
+
+    /// Consumes the builder, returning a new pool.
+    ///
+    /// Unlike `build`, this method does not wait for any connections to be
+    /// established before returning.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `min_idle` is greater than `max_size`.
+    pub fn build_unchecked(self, manager: M) -> AsyncPool<M> {
+        if let Some(min_idle) = self.min_idle {
+            assert!(
+                self.max_size >= min_idle,
+                "min_idle must be no larger than max_size"
+            );
+        }
+
+        let spawn = if let Some(spawn) = self.spawn {
+            spawn
+        } else {
+            let tp = ThreadPool::builder()
+                .pool_size(3)
+                .create()
+                .expect("Could not create thread pool");
+            Box::new(tp)
+        };
+
+        let config = AsyncConfig {
+            max_size: self.max_size,
+            min_idle: self.min_idle,
+            test_on_check_out: self.test_on_check_out,
+            max_lifetime: self.max_lifetime,
+            idle_timeout: self.idle_timeout,
+            connection_timeout: self.connection_timeout,
+            error_handler: self.error_handler,
+            event_handler: self.event_handler,
+            connection_customizer: self.connection_customizer,
+            spawn: spawn,
+            timer: self.timer,
+        };
+
+        AsyncPool::new_inner(config, manager, self.reaper_rate)
+    }
+}
+
+pub struct AsyncConfig<C, E> {
+    pub max_size: u32,
+    pub min_idle: Option<u32>,
+    pub test_on_check_out: bool,
+    pub max_lifetime: Option<Duration>,
+    pub idle_timeout: Option<Duration>,
+    pub connection_timeout: Duration,
+    pub error_handler: Box<dyn HandleError<E>>,
+    pub event_handler: Box<dyn HandleEvent>,
+    pub connection_customizer: Box<dyn AsyncCustomizeConnection<C, E>>,
+    pub spawn: Box<dyn SharedSpawn + Send + Sync>,
+    pub timer: Option<TimerHandle>,
+}
+
+// manual to avoid bounds on C and E
+impl<C, E> fmt::Debug for AsyncConfig<C, E> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Config")
+            .field("max_size", &self.max_size)
+            .field("min_idle", &self.min_idle)
+            .field("test_on_check_out", &self.test_on_check_out)
+            .field("max_lifetime", &self.max_lifetime)
+            .field("idle_timeout", &self.idle_timeout)
+            .field("connection_timeout", &self.connection_timeout)
+            .field("error_handler", &self.error_handler)
+            .field("event_handler", &self.event_handler)
+            .field("connection_customizer", &self.connection_customizer)
+            .field("timer", &self.timer)
+            .finish()
+    }
+}
+
+/// Essentially an alias of `&Spawn`.
+pub trait SharedSpawn {
+    fn spawn_obj(&self, future: FutureObj<'static, ()>) -> Result<(), SpawnError>;
+}
+
+impl<Sp> SharedSpawn for Sp
+where
+    Sp: ?Sized,
+    for<'a> &'a Sp: Spawn,
+{
+    fn spawn_obj(mut self: &Self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
+        Spawn::spawn_obj(&mut self, future)
+    }
+}
+
+impl<'a> Spawn for dyn SharedSpawn + 'a {
+    fn spawn_obj(&mut self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
+        <Self as SharedSpawn>::spawn_obj(self, future)
+    }
+}
+impl<'a> Spawn for &(dyn SharedSpawn + 'a) {
+    fn spawn_obj(&mut self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
+        <dyn SharedSpawn as SharedSpawn>::spawn_obj(*self, future)
+    }
+}
+impl<'a> Spawn for dyn SharedSpawn + Send + 'a {
+    fn spawn_obj(&mut self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
+        <Self as SharedSpawn>::spawn_obj(self, future)
+    }
+}
+impl<'a> Spawn for &(dyn SharedSpawn + Send + 'a) {
+    fn spawn_obj(&mut self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
+        <dyn SharedSpawn as SharedSpawn>::spawn_obj(*self, future)
+    }
+}
+impl<'a> Spawn for dyn SharedSpawn + Send + Sync + 'a {
+    fn spawn_obj(&mut self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
+        <Self as SharedSpawn>::spawn_obj(self, future)
+    }
+}
+impl<'a> Spawn for &(dyn SharedSpawn + Send + Sync + 'a) {
+    fn spawn_obj(&mut self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
+        <dyn SharedSpawn as SharedSpawn>::spawn_obj(*self, future)
+    }
+}

--- a/src/async_/test.rs
+++ b/src/async_/test.rs
@@ -1,0 +1,790 @@
+use futures::future::BoxFuture;
+use futures::prelude::*;
+use futures_timer::Delay;
+use parking_lot::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicIsize, AtomicUsize, Ordering};
+use std::sync::mpsc::{self, Receiver, SyncSender};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use std::{error, fmt, mem};
+
+use super::{AsyncCustomizeConnection, AsyncManageConnection, AsyncPool, AsyncPooledConnection};
+use crate::event::{AcquireEvent, CheckinEvent, CheckoutEvent, ReleaseEvent, TimeoutEvent};
+use crate::HandleEvent;
+
+#[derive(Debug)]
+pub struct Error;
+
+impl fmt::Display for Error {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("blammo")
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        "Error"
+    }
+}
+
+#[derive(Debug, PartialEq)]
+struct FakeConnection(bool);
+
+struct OkManager;
+
+impl AsyncManageConnection for OkManager {
+    type Connection = FakeConnection;
+    type Error = Error;
+
+    fn connect(&self) -> BoxFuture<'_, Result<FakeConnection, Error>> {
+        async move { Ok(FakeConnection(true)) }.boxed()
+    }
+
+    fn is_valid<'a>(&'a self, _: &'a mut FakeConnection) -> BoxFuture<'a, Result<(), Error>> {
+        async move { Ok(()) }.boxed()
+    }
+
+    fn has_broken(&self, _: &mut FakeConnection) -> bool {
+        false
+    }
+}
+
+struct NthConnectFailManager {
+    n: Mutex<u32>,
+}
+
+impl AsyncManageConnection for NthConnectFailManager {
+    type Connection = FakeConnection;
+    type Error = Error;
+
+    fn connect(&self) -> BoxFuture<'_, Result<FakeConnection, Error>> {
+        async move {
+            let mut n = self.n.lock();
+            if *n > 0 {
+                *n -= 1;
+                Ok(FakeConnection(true))
+            } else {
+                Err(Error)
+            }
+        }
+            .boxed()
+    }
+
+    fn is_valid<'a>(&'a self, _: &'a mut FakeConnection) -> BoxFuture<'a, Result<(), Error>> {
+        async move { Ok(()) }.boxed()
+    }
+
+    fn has_broken(&self, _: &mut FakeConnection) -> bool {
+        false
+    }
+}
+
+#[runtime::test]
+async fn test_max_size_ok() {
+    let manager = NthConnectFailManager { n: Mutex::new(5) };
+    let pool = AsyncPool::builder()
+        .max_size(5)
+        .build(manager)
+        .await
+        .unwrap();
+    let mut conns = vec![];
+    for _ in 0..5 {
+        conns.push(pool.get().await.ok().unwrap());
+    }
+}
+
+#[runtime::test]
+async fn test_acquire_release() {
+    let pool = AsyncPool::builder()
+        .max_size(2)
+        .build(OkManager)
+        .await
+        .unwrap();
+
+    let conn1 = pool.get().await.ok().unwrap();
+    let conn2 = pool.get().await.ok().unwrap();
+    drop(conn1);
+    let conn3 = pool.get().await.ok().unwrap();
+    drop(conn2);
+    drop(conn3);
+}
+
+#[runtime::test]
+async fn try_get() {
+    let pool = AsyncPool::builder()
+        .max_size(2)
+        .build(OkManager)
+        .await
+        .unwrap();
+
+    let conn1 = pool.try_get().await;
+    let conn2 = pool.try_get().await;
+    let conn3 = pool.try_get().await;
+
+    assert!(conn1.is_some());
+    assert!(conn2.is_some());
+    assert!(conn3.is_none());
+
+    drop(conn1);
+
+    assert!(pool.try_get().await.is_some());
+}
+
+#[runtime::test]
+async fn get_timeout() {
+    let pool = AsyncPool::builder()
+        .max_size(1)
+        .connection_timeout(Duration::from_millis(500))
+        .build(OkManager)
+        .await
+        .unwrap();
+
+    let timeout = Duration::from_millis(100);
+    let succeeds_immediately = pool.get_timeout(timeout).await;
+
+    assert!(succeeds_immediately.is_ok());
+
+    let t1 = runtime::spawn(async move {
+        Delay::new(Duration::from_millis(50)).await.unwrap();
+        drop(succeeds_immediately);
+    });
+
+    let succeeds_delayed = pool.get_timeout(timeout).await;
+    assert!(succeeds_delayed.is_ok());
+
+    let t2 = runtime::spawn(async move {
+        Delay::new(Duration::from_millis(150)).await.unwrap();
+        drop(succeeds_delayed);
+    });
+
+    let fails = pool.get_timeout(timeout).await;
+    assert!(fails.is_err());
+
+    t1.await;
+    t2.await;
+}
+
+#[test]
+fn test_is_send_sync() {
+    fn is_send_sync<T: Send + Sync>() {}
+    is_send_sync::<AsyncPool<OkManager>>();
+}
+
+#[runtime::test]
+async fn test_issue_2_unlocked_during_is_valid() {
+    struct BlockingChecker {
+        first: AtomicBool,
+        s: Mutex<SyncSender<()>>,
+        r: Mutex<Receiver<()>>,
+    }
+
+    impl AsyncManageConnection for BlockingChecker {
+        type Connection = FakeConnection;
+        type Error = Error;
+
+        fn connect(&self) -> BoxFuture<'_, Result<FakeConnection, Error>> {
+            async move { Ok(FakeConnection(true)) }.boxed()
+        }
+
+        fn is_valid<'a>(&'a self, _: &'a mut FakeConnection) -> BoxFuture<'a, Result<(), Error>> {
+            async move {
+                if self.first.compare_and_swap(true, false, Ordering::SeqCst) {
+                    self.s.lock().send(()).unwrap();
+                    self.r.lock().recv().unwrap();
+                }
+                Ok(())
+            }
+                .boxed()
+        }
+
+        fn has_broken(&self, _: &mut FakeConnection) -> bool {
+            false
+        }
+    }
+
+    let (s1, r1) = mpsc::sync_channel(0);
+    let (s2, r2) = mpsc::sync_channel(0);
+
+    let manager = BlockingChecker {
+        first: AtomicBool::new(true),
+        s: Mutex::new(s1),
+        r: Mutex::new(r2),
+    };
+
+    let pool = AsyncPool::builder()
+        .test_on_check_out(true)
+        .max_size(2)
+        .build(manager)
+        .await
+        .unwrap();
+
+    let p2 = pool.clone();
+    let t = runtime::spawn(async move {
+        p2.get().await.ok().unwrap();
+    });
+
+    r1.recv().unwrap();
+    // get call by other task has triggered the health check
+    pool.get().await.ok().unwrap();
+    s2.send(()).ok().unwrap();
+
+    t.await;
+}
+
+#[runtime::test]
+async fn test_drop_on_broken() {
+    static DROPPED: AtomicBool = AtomicBool::new(false);
+    DROPPED.store(false, Ordering::SeqCst);
+
+    struct Connection;
+
+    impl Drop for Connection {
+        fn drop(&mut self) {
+            DROPPED.store(true, Ordering::SeqCst);
+        }
+    }
+
+    struct Handler;
+
+    impl AsyncManageConnection for Handler {
+        type Connection = Connection;
+        type Error = Error;
+
+        fn connect(&self) -> BoxFuture<'_, Result<Connection, Error>> {
+            async move { Ok(Connection) }.boxed()
+        }
+
+        fn is_valid<'a>(&'a self, _: &'a mut Connection) -> BoxFuture<'a, Result<(), Error>> {
+            async move { Ok(()) }.boxed()
+        }
+
+        fn has_broken(&self, _: &mut Connection) -> bool {
+            true
+        }
+    }
+
+    let pool = AsyncPool::new(Handler).await.unwrap();
+
+    drop(pool.get().await.ok().unwrap());
+
+    assert!(DROPPED.load(Ordering::SeqCst));
+}
+
+#[runtime::test]
+async fn test_initialization_failure() {
+    let manager = NthConnectFailManager { n: Mutex::new(0) };
+    let err = AsyncPool::builder()
+        .connection_timeout(Duration::from_secs(1))
+        .build(manager)
+        .await
+        .err()
+        .unwrap();
+    assert!(err.to_string().contains("blammo"));
+}
+
+#[runtime::test]
+async fn test_lazy_initialization_failure() {
+    let manager = NthConnectFailManager { n: Mutex::new(0) };
+    let pool = AsyncPool::builder()
+        .connection_timeout(Duration::from_secs(1))
+        .build_unchecked(manager);
+    let err = pool.get().await.err().unwrap();
+    assert!(err.to_string().contains("blammo"));
+}
+
+#[runtime::test]
+async fn test_get_global_timeout() {
+    let pool = AsyncPool::builder()
+        .max_size(1)
+        .connection_timeout(Duration::from_secs(1))
+        .build(OkManager)
+        .await
+        .unwrap();
+    let _c = pool.get().await.unwrap();
+    let started_waiting = Instant::now();
+    pool.get().await.err().unwrap();
+    // Elapsed time won't be *exactly* 1 second, but it will certainly be
+    // less than 2 seconds
+    assert_eq!(started_waiting.elapsed().as_secs(), 1);
+}
+
+#[runtime::test]
+async fn test_connection_customizer() {
+    static RELEASED: AtomicBool = AtomicBool::new(false);
+    RELEASED.store(false, Ordering::SeqCst);
+
+    static DROPPED: AtomicBool = AtomicBool::new(false);
+    DROPPED.store(false, Ordering::SeqCst);
+
+    struct Connection(i32);
+
+    impl Drop for Connection {
+        fn drop(&mut self) {
+            DROPPED.store(true, Ordering::SeqCst);
+        }
+    }
+
+    struct Handler;
+
+    impl AsyncManageConnection for Handler {
+        type Connection = Connection;
+        type Error = Error;
+
+        fn connect(&self) -> BoxFuture<'_, Result<Connection, Error>> {
+            async move { Ok(Connection(0)) }.boxed()
+        }
+
+        fn is_valid<'a>(&'a self, _: &'a mut Connection) -> BoxFuture<'a, Result<(), Error>> {
+            async move { Ok(()) }.boxed()
+        }
+
+        fn has_broken(&self, _: &mut Connection) -> bool {
+            true
+        }
+    }
+
+    #[derive(Debug)]
+    struct Customizer;
+
+    impl AsyncCustomizeConnection<Connection, Error> for Customizer {
+        fn on_acquire<'a>(&'a self, conn: &'a mut Connection) -> BoxFuture<'a, Result<(), Error>> {
+            async move {
+                if !DROPPED.load(Ordering::SeqCst) {
+                    Err(Error)
+                } else {
+                    conn.0 = 1;
+                    Ok(())
+                }
+            }
+                .boxed()
+        }
+
+        fn on_release(&self, _: Connection) {
+            RELEASED.store(true, Ordering::SeqCst);
+        }
+    }
+
+    let pool = AsyncPool::builder()
+        .connection_customizer(Box::new(Customizer))
+        .build(Handler)
+        .await
+        .unwrap();
+
+    {
+        let conn = pool.get().await.unwrap();
+        assert_eq!(1, conn.0);
+        assert!(!RELEASED.load(Ordering::SeqCst));
+        assert!(DROPPED.load(Ordering::SeqCst));
+    }
+    assert!(RELEASED.load(Ordering::SeqCst));
+}
+
+#[runtime::test]
+async fn test_idle_timeout() {
+    static DROPPED: AtomicUsize = AtomicUsize::new(0);
+
+    struct Connection;
+
+    impl Drop for Connection {
+        fn drop(&mut self) {
+            DROPPED.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    struct Handler(AtomicIsize);
+
+    impl AsyncManageConnection for Handler {
+        type Connection = Connection;
+        type Error = Error;
+
+        fn connect(&self) -> BoxFuture<'_, Result<Connection, Error>> {
+            async move {
+                if self.0.fetch_sub(1, Ordering::SeqCst) > 0 {
+                    Ok(Connection)
+                } else {
+                    Err(Error)
+                }
+            }
+                .boxed()
+        }
+
+        fn is_valid<'a>(&'a self, _: &'a mut Connection) -> BoxFuture<'a, Result<(), Error>> {
+            async move { Ok(()) }.boxed()
+        }
+
+        fn has_broken(&self, _: &mut Connection) -> bool {
+            false
+        }
+    }
+
+    let pool = AsyncPool::builder()
+        .max_size(5)
+        .idle_timeout(Some(Duration::from_secs(1)))
+        .reaper_rate(Duration::from_secs(1))
+        .build(Handler(AtomicIsize::new(5)))
+        .await
+        .unwrap();
+    let conn = pool.get().await.unwrap();
+    Delay::new(Duration::from_secs(2)).await.unwrap();
+    assert_eq!(4, DROPPED.load(Ordering::SeqCst));
+    drop(conn);
+    assert_eq!(4, DROPPED.load(Ordering::SeqCst));
+}
+
+#[runtime::test]
+async fn idle_timeout_partial_use() {
+    static DROPPED: AtomicUsize = AtomicUsize::new(0);
+
+    struct Connection;
+
+    impl Drop for Connection {
+        fn drop(&mut self) {
+            DROPPED.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    struct Handler(AtomicIsize);
+
+    impl AsyncManageConnection for Handler {
+        type Connection = Connection;
+        type Error = Error;
+
+        fn connect(&self) -> BoxFuture<'_, Result<Connection, Error>> {
+            async move {
+                if self.0.fetch_sub(1, Ordering::SeqCst) > 0 {
+                    Ok(Connection)
+                } else {
+                    Err(Error)
+                }
+            }
+                .boxed()
+        }
+
+        fn is_valid<'a>(&'a self, _: &'a mut Connection) -> BoxFuture<'a, Result<(), Error>> {
+            async move { Ok(()) }.boxed()
+        }
+
+        fn has_broken(&self, _: &mut Connection) -> bool {
+            false
+        }
+    }
+
+    let pool = AsyncPool::builder()
+        .max_size(5)
+        .idle_timeout(Some(Duration::from_secs(1)))
+        .reaper_rate(Duration::from_secs(1))
+        .build(Handler(AtomicIsize::new(5)))
+        .await
+        .unwrap();
+    for _ in 0..8 {
+        Delay::new(Duration::from_millis(250)).await.unwrap();
+        pool.get().await.unwrap();
+    }
+    assert_eq!(4, DROPPED.load(Ordering::SeqCst));
+    assert_eq!(1, pool.state().connections);
+}
+
+#[runtime::test]
+async fn test_max_lifetime() {
+    static DROPPED: AtomicUsize = AtomicUsize::new(0);
+
+    struct Connection;
+
+    impl Drop for Connection {
+        fn drop(&mut self) {
+            DROPPED.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    struct Handler(AtomicIsize);
+
+    impl AsyncManageConnection for Handler {
+        type Connection = Connection;
+        type Error = Error;
+
+        fn connect(&self) -> BoxFuture<'_, Result<Connection, Error>> {
+            async move {
+                if self.0.fetch_sub(1, Ordering::SeqCst) > 0 {
+                    Ok(Connection)
+                } else {
+                    Err(Error)
+                }
+            }
+                .boxed()
+        }
+
+        fn is_valid<'a>(&'a self, _: &'a mut Connection) -> BoxFuture<'a, Result<(), Error>> {
+            async move { Ok(()) }.boxed()
+        }
+
+        fn has_broken(&self, _: &mut Connection) -> bool {
+            false
+        }
+    }
+
+    let pool = AsyncPool::builder()
+        .max_size(5)
+        .max_lifetime(Some(Duration::from_secs(1)))
+        .connection_timeout(Duration::from_secs(1))
+        .reaper_rate(Duration::from_secs(1))
+        .build(Handler(AtomicIsize::new(5)))
+        .await
+        .unwrap();
+    let conn = pool.get().await.unwrap();
+    Delay::new(Duration::from_secs(2)).await.unwrap();
+    assert_eq!(4, DROPPED.load(Ordering::SeqCst));
+    drop(conn);
+    Delay::new(Duration::from_secs(2)).await.unwrap();
+    assert_eq!(5, DROPPED.load(Ordering::SeqCst));
+    assert!(pool.get().await.is_err());
+}
+
+#[runtime::test]
+async fn min_idle() {
+    struct Connection;
+
+    struct Handler;
+
+    impl AsyncManageConnection for Handler {
+        type Connection = Connection;
+        type Error = Error;
+
+        fn connect(&self) -> BoxFuture<'_, Result<Connection, Error>> {
+            async move { Ok(Connection) }.boxed()
+        }
+
+        fn is_valid<'a>(&'a self, _: &'a mut Connection) -> BoxFuture<'a, Result<(), Error>> {
+            async move { Ok(()) }.boxed()
+        }
+
+        fn has_broken(&self, _: &mut Connection) -> bool {
+            false
+        }
+    }
+
+    let pool = AsyncPool::builder()
+        .max_size(5)
+        .min_idle(Some(2))
+        .build(Handler)
+        .await
+        .unwrap();
+    Delay::new(Duration::from_secs(1)).await.unwrap();
+    assert_eq!(2, pool.state().idle_connections);
+    assert_eq!(2, pool.state().connections);
+    let conns = stream::iter(0..3)
+        .then(|_| async { pool.get().await.unwrap() })
+        .collect::<Vec<_>>()
+        .await;
+    Delay::new(Duration::from_secs(1)).await.unwrap();
+    assert_eq!(2, pool.state().idle_connections);
+    assert_eq!(5, pool.state().connections);
+    mem::drop(conns);
+    assert_eq!(5, pool.state().idle_connections);
+    assert_eq!(5, pool.state().connections);
+}
+
+#[runtime::test]
+async fn conns_drop_on_pool_drop() {
+    static DROPPED: AtomicUsize = AtomicUsize::new(0);
+
+    struct Connection;
+
+    impl Drop for Connection {
+        fn drop(&mut self) {
+            DROPPED.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    struct Handler;
+
+    impl AsyncManageConnection for Handler {
+        type Connection = Connection;
+        type Error = Error;
+
+        fn connect(&self) -> BoxFuture<'_, Result<Connection, Error>> {
+            async move { Ok(Connection) }.boxed()
+        }
+
+        fn is_valid<'a>(&'a self, _: &'a mut Connection) -> BoxFuture<'a, Result<(), Error>> {
+            async move { Ok(()) }.boxed()
+        }
+
+        fn has_broken(&self, _: &mut Connection) -> bool {
+            false
+        }
+    }
+
+    let pool = AsyncPool::builder()
+        .max_lifetime(Some(Duration::from_secs(10)))
+        .max_size(10)
+        .build(Handler)
+        .await
+        .unwrap();
+    drop(pool);
+    for _ in 0..10 {
+        if DROPPED.load(Ordering::SeqCst) == 10 {
+            return;
+        }
+        Delay::new(Duration::from_secs(1)).await.unwrap();
+    }
+    panic!("timed out waiting for connections to drop");
+}
+
+#[runtime::test]
+async fn events() {
+    #[derive(Debug)]
+    enum Event {
+        Acquire(AcquireEvent),
+        Release(ReleaseEvent),
+        Checkout(CheckoutEvent),
+        Checkin(CheckinEvent),
+        Timeout(TimeoutEvent),
+    }
+
+    #[derive(Debug)]
+    struct TestEventHandler(Arc<Mutex<Vec<Event>>>);
+
+    impl HandleEvent for TestEventHandler {
+        fn handle_acquire(&self, event: AcquireEvent) {
+            self.0.lock().push(Event::Acquire(event));
+        }
+
+        fn handle_release(&self, event: ReleaseEvent) {
+            self.0.lock().push(Event::Release(event));
+        }
+
+        fn handle_checkout(&self, event: CheckoutEvent) {
+            self.0.lock().push(Event::Checkout(event));
+        }
+
+        fn handle_timeout(&self, event: TimeoutEvent) {
+            self.0.lock().push(Event::Timeout(event));
+        }
+
+        fn handle_checkin(&self, event: CheckinEvent) {
+            self.0.lock().push(Event::Checkin(event));
+        }
+    }
+
+    struct TestConnection;
+
+    struct TestConnectionManager;
+
+    impl AsyncManageConnection for TestConnectionManager {
+        type Connection = TestConnection;
+        type Error = Error;
+
+        fn connect(&self) -> BoxFuture<'_, Result<TestConnection, Error>> {
+            async move {
+                // Avoid acquisition-before-release flakiness
+                Delay::new(Duration::from_millis(10)).await.unwrap();
+                Ok(TestConnection)
+            }
+                .boxed()
+        }
+
+        fn is_valid<'a>(&'a self, _: &'a mut TestConnection) -> BoxFuture<'a, Result<(), Error>> {
+            async move { Ok(()) }.boxed()
+        }
+
+        fn has_broken(&self, _: &mut TestConnection) -> bool {
+            true
+        }
+    }
+
+    let events = Arc::new(Mutex::new(vec![]));
+
+    let creation = Instant::now();
+    let pool = AsyncPool::builder()
+        .max_size(1)
+        .connection_timeout(Duration::from_millis(250))
+        .event_handler(Box::new(TestEventHandler(events.clone())))
+        .build(TestConnectionManager)
+        .await
+        .unwrap();
+
+    let start = Instant::now();
+    let conn = pool.get().await.unwrap();
+    let checkout = start.elapsed();
+
+    pool.get_timeout(Duration::from_millis(123))
+        .await
+        .err()
+        .unwrap();
+
+    drop(conn);
+    let checkin = start.elapsed();
+    let release = creation.elapsed();
+
+    let _conn2 = pool.get().await.unwrap();
+
+    let events = events.lock();
+
+    let id = match events[0] {
+        Event::Acquire(ref event) => event.connection_id(),
+        _ => unreachable!(),
+    };
+
+    match events[1] {
+        Event::Checkout(ref event) => {
+            assert_eq!(event.connection_id(), id);
+            assert!(event.duration() <= checkout);
+        }
+        _ => unreachable!(),
+    }
+
+    match events[2] {
+        Event::Timeout(ref event) => assert_eq!(event.timeout(), Duration::from_millis(123)),
+        _ => unreachable!(),
+    }
+
+    match events[3] {
+        Event::Checkin(ref event) => {
+            assert_eq!(event.connection_id(), id);
+            assert!(event.duration() <= checkin);
+        }
+        _ => unreachable!(),
+    }
+
+    match events[4] {
+        Event::Release(ref event) => {
+            assert_eq!(event.connection_id(), id);
+            assert!(event.age() <= release);
+        }
+        _ => unreachable!(),
+    }
+
+    let id2 = match events[5] {
+        Event::Acquire(ref event) => event.connection_id(),
+        _ => unreachable!(),
+    };
+    assert!(id < id2);
+
+    match events[6] {
+        Event::Checkout(ref event) => assert_eq!(event.connection_id(), id2),
+        _ => unreachable!(),
+    }
+}
+
+#[runtime::test]
+async fn extensions() {
+    let pool = AsyncPool::builder()
+        .max_size(2)
+        .build(OkManager)
+        .await
+        .unwrap();
+
+    let mut conn1 = pool.get().await.unwrap();
+    let mut conn2 = pool.get().await.unwrap();
+
+    AsyncPooledConnection::extensions_mut(&mut conn1).insert(1);
+    AsyncPooledConnection::extensions_mut(&mut conn2).insert(2);
+
+    drop(conn1);
+
+    let conn = pool.get().await.unwrap();
+    assert_eq!(
+        AsyncPooledConnection::extensions(&conn).get::<i32>(),
+        Some(&1)
+    );
+}


### PR DESCRIPTION
This is an attempt to provide an async-Rust equivalent of the current `r2d2` connection pool.

- The interface is mostly kept parallel to the blocking implementation. There is a slight difference in configuration parameters for thread pools.
- Connection establishment and probing are made asynchronous. Disconnection and logging are kept synchronous.
- Designed to be tolerant against Future cancellation, but not tested well.

Things that are not polished yet:

- Depends on `#![feature(async_await)]` until Rust 1.38 release.
- Dev-dependency can't be toggled via features. We may have to bump dev-MSRV to 1.36 (futures_api) or 1.38 (async_await).
- There might be cyclic reference issues. Needs to be checked.
- Tests for future cancellation
- Designated documentation, at least about feature flags.
- There's the definition of `SharedSpawn` which doesn't deserve in this crate.
- Module layout and exports.
- Handle spawn errors and timer failures better.