### PR TITLE
Derive PartialEq for Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -551,7 +551,7 @@ where
 }
 
 /// The error type returned by methods in this crate.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Error(Option<String>);
 
 impl fmt::Display for Error {


### PR DESCRIPTION
This helps when wrapping this crate's Error struct in another
crate. Not sure if you'd like a test to cover this too, but if so just let me know.