### PR TITLE
Adds an `always_keep_alive` function for in-memory databases like sqlite

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -176,6 +176,14 @@ where
         self
     }
 
+    /// Sets settings to never allow dropping connections. This is useful for in-memory (like
+    /// SQLite's ":memory:") databases.
+    ///
+    /// Is equivalent to calling `max_size(1)`, `idle_timeout(None)` and `max_lifetime(None)`.
+    pub fn always_keep_alive(mut self) -> Builder<M> {
+        self.max_size(1).idle_timeout(None).max_lifetime(None)
+    }
+
     /// Sets the handler for errors reported in the pool.
     ///
     /// Defaults to the `LoggingErrorHandler`.


### PR DESCRIPTION
Because of things like [tokio-diesel](https://github.com/mehcode/tokio-diesel), sometimes it makes sense to use r2d2 with an in-memory database. It was very confusing to see r2d2 handle things totally fine until 30 minutes (max lifetime), until realizing what was actually happening.

This could very well be a documentation item too, I have no real opinion. But somewhere greppable for `:memory:`/sqlite would be awesome.