### PR TITLE
add #![forbid(unsafe_code)]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # r2d2
 [![CircleCI](https://circleci.com/gh/sfackler/r2d2.svg?style=shield)](https://circleci.com/gh/sfackler/r2d2)
+[![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 
 A generic connection pool for Rust.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@
 //! ```
 #![warn(missing_docs)]
 #![doc(html_root_url = "https://docs.rs/r2d2/0.8")]
+#![forbid(unsafe_code)]
 
 use log::error;
 


### PR DESCRIPTION
this crate does not use unsafe code, so we can forbid it completely to
ensure that it won't be added later on and to tell analysers that this
is the case.

for more information see also here: https://github.com/rust-secure-code/safety-dance