### PR TITLE
add r2d2-firebird crate to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Backend                                                                | Adaptor
 [rust-memcache](https://github.com/aisk/rust-memcache)                 | [r2d2-memcache](https://github.com/megumish/r2d2-memcache)
 [rust-mysql-simple](https://github.com/blackbeam/rust-mysql-simple)    | [r2d2-mysql](https://github.com/outersky/r2d2-mysql)
 [rusqlite](https://github.com/jgallagher/rusqlite)                     | [r2d2-sqlite](https://github.com/ivanceras/r2d2-sqlite)
+[rsfbclient](https://github.com/fernandobatels/rsfbclient)                     | [r2d2-firebird](https://crates.io/crates/r2d2_firebird/)
 [rusted-cypher](https://github.com/livioribeiro/rusted-cypher)         | [r2d2-cypher](https://github.com/flosse/r2d2-cypher)
 [diesel](https://github.com/sgrif/diesel)                              | [diesel::r2d2](https://github.com/diesel-rs/diesel/blob/master/diesel/src/r2d2.rs) ([docs](https://docs.diesel.rs/diesel/r2d2/))
 [couchdb](https://github.com/chill-rs/chill)                           | [r2d2-couchdb](https://github.com/scorphus/r2d2-couchdb)


### PR DESCRIPTION
add r2d2-firebird crate to readme https://crates.io/crates/r2d2_firebird/
with rsfbclient backend https://github.com/fernandobatels/rsfbclient

split done via pull request https://github.com/fernandobatels/rsfbclient/pull/99