### PR TITLE
remove deprecated functions & fix style

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -136,7 +136,11 @@ where
     ///
     /// Panics if `max_lifetime` is the zero `Duration`.
     pub fn max_lifetime(mut self, max_lifetime: Option<Duration>) -> Builder<M> {
-        assert_ne!(max_lifetime, Some(Duration::from_secs(0)), "max_lifetime must be positive");
+        assert_ne!(
+            max_lifetime,
+            Some(Duration::from_secs(0)),
+            "max_lifetime must be positive"
+        );
         self.max_lifetime = max_lifetime;
         self
     }
@@ -152,7 +156,11 @@ where
     ///
     /// Panics if `idle_timeout` is the zero `Duration`.
     pub fn idle_timeout(mut self, idle_timeout: Option<Duration>) -> Builder<M> {
-        assert_ne!(idle_timeout, Some(Duration::from_secs(0)), "idle_timeout must be positive");
+        assert_ne!(
+            idle_timeout,
+            Some(Duration::from_secs(0)),
+            "idle_timeout must be positive"
+        );
         self.idle_timeout = idle_timeout;
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -515,7 +515,6 @@ where
         State {
             connections: internals.num_conns,
             idle_connections: internals.conns.len() as u32,
-            _p: (),
         }
     }
 
@@ -556,7 +555,7 @@ pub struct Error(Option<String>);
 
 impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str(error::Error::description(self))?;
+        fmt.write_str("timed out waiting for connection")?;
         if let Some(ref err) = self.0 {
             write!(fmt, ": {}", err)?;
         }
@@ -564,28 +563,16 @@ impl fmt::Display for Error {
     }
 }
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        "timed out waiting for connection"
-    }
-}
+impl error::Error for Error {}
 
 /// Information about the state of a `Pool`.
+#[non_exhaustive]
+#[derive(Debug)]
 pub struct State {
     /// The number of connections currently being managed by the pool.
     pub connections: u32,
     /// The number of idle connections.
     pub idle_connections: u32,
-    _p: (),
-}
-
-impl fmt::Debug for State {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.debug_struct("State")
-            .field("connections", &self.connections)
-            .field("idle_connections", &self.idle_connections)
-            .finish()
-    }
 }
 
 /// A smart pointer wrapping a connection.

--- a/src/test.rs
+++ b/src/test.rs
@@ -164,7 +164,11 @@ fn test_issue_2_unlocked_during_is_valid() {
         }
 
         fn is_valid(&self, _: &mut FakeConnection) -> Result<(), Error> {
-            if self.first.compare_and_swap(true, false, Ordering::SeqCst) {
+            if self
+                .first
+                .compare_exchange(true, false, Ordering::SeqCst, Ordering::SeqCst)
+                .unwrap_or_else(|e| e)
+            {
                 self.s.lock().send(()).unwrap();
                 self.r.lock().recv().unwrap();
             }


### PR DESCRIPTION
- run `cargo fmt` on codes
- fix [manual_non_exhaustive](https://rust-lang.github.io/rust-clippy/master/index.html#manual_non_exhaustive)
- remove deprecated function `std::error::Error::description`

close #118 