### PR TITLE
drop idle connections immediately after the pool is dropped

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,6 +313,39 @@ where
     drop_conns(&shared, internals, to_drop);
 }
 
+fn put_back_connection<M>(
+    pool: &Weak<SharedPool<M>>,
+    checkout: Instant,
+    mut conn: Conn<M::Connection>,
+) where
+    M: ManageConnection,
+{
+    let pool = match pool.upgrade() {
+        Some(pool) => pool,
+        None => return,
+    };
+    let event = CheckinEvent {
+        id: conn.id,
+        duration: checkout.elapsed(),
+    };
+    pool.config.event_handler.handle_checkin(event);
+
+    // This is specified to be fast, but call it before locking anyways
+    let broken = pool.manager.has_broken(&mut conn.conn);
+
+    let mut internals = pool.internals.lock();
+    if broken {
+        drop_conns(&pool, internals, vec![conn]);
+    } else {
+        let conn = IdleConn {
+            conn,
+            idle_start: Instant::now(),
+        };
+        internals.conns.push(conn);
+        pool.cond.notify_one();
+    }
+}
+
 /// A generic connection pool.
 pub struct Pool<M>(Arc<SharedPool<M>>)
 where
@@ -476,36 +509,13 @@ where
                 }
 
                 return Ok(PooledConnection {
-                    pool: self.clone(),
+                    pool: Arc::downgrade(&self.0),
                     checkout: Instant::now(),
                     conn: Some(conn.conn),
                 });
             } else {
                 return Err(internals);
             }
-        }
-    }
-
-    fn put_back(&self, checkout: Instant, mut conn: Conn<M::Connection>) {
-        let event = CheckinEvent {
-            id: conn.id,
-            duration: checkout.elapsed(),
-        };
-        self.0.config.event_handler.handle_checkin(event);
-
-        // This is specified to be fast, but call it before locking anyways
-        let broken = self.0.manager.has_broken(&mut conn.conn);
-
-        let mut internals = self.0.internals.lock();
-        if broken {
-            drop_conns(&self.0, internals, vec![conn]);
-        } else {
-            let conn = IdleConn {
-                conn,
-                idle_start: Instant::now(),
-            };
-            internals.conns.push(conn);
-            self.0.cond.notify_one();
         }
     }
 
@@ -593,7 +603,7 @@ pub struct PooledConnection<M>
 where
     M: ManageConnection,
 {
-    pool: Pool<M>,
+    pool: Weak<SharedPool<M>>,
     checkout: Instant,
     conn: Option<Conn<M::Connection>>,
 }
@@ -613,7 +623,7 @@ where
     M: ManageConnection,
 {
     fn drop(&mut self) {
-        self.pool.put_back(self.checkout, self.conn.take().unwrap());
+        put_back_connection(&self.pool, self.checkout, self.conn.take().unwrap());
     }
 }
 


### PR DESCRIPTION
I found that when the pool is dropped with some connections remain in lifetime, ALL idle connections will not drop until the connection checked out is dropped. Changing `pool`  field in `PooledConnection` to `Weak<SharedPool<M>>` can fix this problem.

For example:

```rust
use std::{
    sync::RwLock,
    thread::sleep,
    time::{Duration, Instant},
};

use r2d2::{ManageConnection, Pool};

struct FooConnection;

impl FooConnection {
    fn new() -> FooConnection {
        println!("connection");
        FooConnection
    }
}

impl Drop for FooConnection {
    fn drop(&mut self) {
        println!("drop connection, t: {:?}", Instant::now());
    }
}

struct FooManager;

impl ManageConnection for FooManager {
    type Connection = FooConnection;
    type Error = std::io::Error;

    fn connect(&self) -> Result<FooConnection, Self::Error> {
        Ok(FooConnection::new())
    }

    fn is_valid(&self, _: &mut FooConnection) -> Result<(), Self::Error> {
        Ok(())
    }

    fn has_broken(&self, _: &mut FooConnection) -> bool {
        false
    }
}

static POOL: RwLock<Option<Pool<FooManager>>> = RwLock::new(None);

fn main() -> anyhow::Result<()> {
    let pool = r2d2::Pool::builder()
        .min_idle(Some(2))
        .max_size(4)
        .build(FooManager)?;

    *POOL.write().unwrap() = Some(pool);

    std::thread::spawn(|| {
        let _conn = POOL.read().unwrap().as_ref().unwrap().get().unwrap();
        sleep(Duration::from_secs(5));
        // <- all connections dropped here before our change

        // <- only `_conn` dropped here after our change
        // <- other idle connections will dropped eralier.
    });
    sleep(Duration::from_micros(5000));

    {
        let _ = POOL.write().unwrap().take();
        // <- all IDLE connections will dropped here after our change
    }

    sleep(Duration::from_secs(10));
    Ok(())
}

```