### PR TITLE
Fix diesel r2d2 link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Backend                                                                | Adaptor
 [rusqlite](https://github.com/jgallagher/rusqlite)                     | [r2d2-sqlite](https://github.com/ivanceras/r2d2-sqlite)
 [rsfbclient](https://github.com/fernandobatels/rsfbclient)                     | [r2d2-firebird](https://crates.io/crates/r2d2_firebird/)
 [rusted-cypher](https://github.com/livioribeiro/rusted-cypher)         | [r2d2-cypher](https://github.com/flosse/r2d2-cypher)
-[diesel](https://github.com/sgrif/diesel)                              | [diesel::r2d2](https://github.com/diesel-rs/diesel/blob/master/diesel/src/r2d2.rs) ([docs](https://docs.diesel.rs/diesel/r2d2/))
+[diesel](https://github.com/sgrif/diesel)                              | [diesel::r2d2](https://github.com/diesel-rs/diesel/blob/master/diesel/src/r2d2.rs) ([docs](https://docs.rs/diesel/latest/diesel/r2d2/index.html))
 [couchdb](https://github.com/chill-rs/chill)                           | [r2d2-couchdb](https://github.com/scorphus/r2d2-couchdb)
 [mongodb (archived)](https://github.com/mongodb-labs/mongo-rust-driver-prototype)<br>use official [mongodb](https://github.com/mongodb/mongo-rust-driver) driver instead                             | [r2d2-mongodb](https://gitlab.com/petoknm/r2d2-mongodb)<br>(deprecated: official driver handles pooling internally)
 [odbc](https://github.com/Koka/odbc-rs)                                | [r2d2-odbc](https://github.com/Koka/r2d2-odbc)


### PR DESCRIPTION
The old link was a 404. It looks like docs.diesel.rs just links to its own crate docs on docs.rs now, so might as well link there directly.